### PR TITLE
wroks on SDXL but broken on SD1.5

### DIFF
--- a/scripts/frequency_separation.py
+++ b/scripts/frequency_separation.py
@@ -17,6 +17,7 @@ Synchronization modes prevent ghosting and spatial misalignment:
 - Shared latent: Mixed processing with spatial guidance
 """
 
+from ldm.modules.distributions.distributions import DiagonalGaussianDistribution
 import math
 from typing import Dict, List, Tuple, Optional, Union
 from dataclasses import dataclass
@@ -1201,7 +1202,10 @@ class FrequencySeparationScript(scripts.Script):
                     latent = p.sd_model.first_stage_model.encode(image_tensor)
                 else:
                     raise Exception("No VAE encoder method found")
-                
+
+                if isinstance(latent, DiagonalGaussianDistribution):
+                    latent = latent.parameters
+
                 # Apply scaling factor if present
                 if hasattr(p.sd_model, 'scale_factor'):
                     latent = latent * p.sd_model.scale_factor

--- a/scripts/frequency_separation.py
+++ b/scripts/frequency_separation.py
@@ -1304,7 +1304,7 @@ class FrequencySeparationScript(scripts.Script):
         try:
             # Convert BFloat16 to Float32 for FFT operations if needed
             original_dtype = latent.dtype
-            if latent.dtype == torch.bfloat16:
+            if latent.dtype in (torch.bfloat16, torch.float16):
                 latent = latent.float()
             
             # Apply FFT to latent channels
@@ -1353,7 +1353,7 @@ class FrequencySeparationScript(scripts.Script):
                 band_latent = torch.fft.ifftn(band_freq, dim=(-2, -1)).real
                 
                 # Convert back to original dtype if needed
-                if original_dtype == torch.bfloat16:
+                if original_dtype != band_latent.dtype:
                     band_latent = band_latent.to(original_dtype)
                 
                 frequency_bands[band_config.name] = band_latent


### PR DESCRIPTION
## sorry this should be more of an issue post than a PR

but as I have written something I wish to show I think making a PR is more convenient
you can merge this if you think it's useful if it's not they just close it

---

in read me you wrote
> Tested Compatibility
AUTOMATIC1111: v1.9.4

well I tried it and it doesn't seem to work on my a1111
at this point I'm not totally sure why your extension seems to work on [Konpr](https://github.com/Konpr) from https://github.com/thavocado/sd-webui-frequency-separation/issues/3 bot not my setup

so far all my outfits are all garbage images,
initially my outputs are noise, using the current fix I managed to make it into a black image

> update your code currently not work with SD1.5 but seems to work with SDXL

---

## they're at least two potentially more issues in your code the first one I addressed in this

### first one is the one I address in this "PR"

your code seems to expect the `latent` from `encode_first_stage()` is a torch tensor
but for me it retruns a custom obj `DiagonalGaussianDistribution` and so your code will break
and if I'm guessing your code correctly you seems to be only interested `DiagonalGaussianDistribution.parameters` and calculate mean std min max yourself

> update: `DiagonalGaussianDistribution` is retruned as latent when using SD1.5, retruns Tensor in SDXL

### next issue about torch FFT when running on CUDA

> if you had read what I read it before I miss remember some information

https://github.com/thavocado/sd-webui-frequency-separation/blob/af639aee9066b5195814d41ec54051070005845a/scripts/frequency_separation.py#L1300-L1307

hear you only convert bf16 tp fp32, but it is alsob possilbe of it to be fp16